### PR TITLE
Avoid empty regex alternatives for comments

### DIFF
--- a/src/commentConfigHandler.ts
+++ b/src/commentConfigHandler.ts
@@ -81,15 +81,17 @@ export class CommentConfigHandler {
 
         // Update regex
         const ccc = this.currentCommentConfig;
-        let regExString = '';
-        if (!!ccc?.lineComment)
-            regExString += String.raw`(${escapeRegex(ccc.lineComment)})(.*)`;
-        if (regExString) regExString += '|';
-        if (!!ccc?.blockComment)
-            regExString += String.raw`(${escapeRegex(ccc.blockComment[0])})([\S\s]*?)(${escapeRegex(ccc.blockComment[1])})`;
-        if (!regExString) return null;
+        const patterns: string[] = [];
 
-        this.regex = RegExp(regExString, "g");
+        if (ccc?.lineComment)
+            patterns.push(String.raw`(${escapeRegex(ccc.lineComment)})(.*)`);
+
+        if (ccc?.blockComment)
+            patterns.push(String.raw`(${escapeRegex(ccc.blockComment[0])})([\S\s]*?)(${escapeRegex(ccc.blockComment[1])})`);
+
+        if (!patterns.length) return null;
+
+        this.regex = RegExp(patterns.join('|'), "g");
     }
 
     /**

--- a/src/commentConfigHandler.ts
+++ b/src/commentConfigHandler.ts
@@ -79,19 +79,24 @@ export class CommentConfigHandler {
 
         if (!this.currentCommentConfig) return;
 
+        // === Fix for Bash (shellscript) === {#110}
+        // In some languages a line comment is available, but the block comment is not.
+        // In such cases, the old regex was terminated with a trailing '|' and make the plugin to crash.
+        // Now the regex is build with `regExString.join('|')` to avoid the final '|'...
+        
         // Update regex
         const ccc = this.currentCommentConfig;
-        const patterns: string[] = [];
+        const regExString: string[] = [];
 
         if (ccc?.lineComment)
-            patterns.push(String.raw`(${escapeRegex(ccc.lineComment)})(.*)`);
+            regExString.push(String.raw`(${escapeRegex(ccc.lineComment)})(.*)`);
 
         if (ccc?.blockComment)
-            patterns.push(String.raw`(${escapeRegex(ccc.blockComment[0])})([\S\s]*?)(${escapeRegex(ccc.blockComment[1])})`);
+            regExString.push(String.raw`(${escapeRegex(ccc.blockComment[0])})([\S\s]*?)(${escapeRegex(ccc.blockComment[1])})`);
 
-        if (!patterns.length) return null;
+        if (!regExString.length) return null;
 
-        this.regex = RegExp(patterns.join('|'), "g");
+        this.regex = RegExp(regExString.join('|'), "g");
     }
 
     /**

--- a/src/decorationRangeHandler.ts
+++ b/src/decorationRangeHandler.ts
@@ -107,8 +107,6 @@ export class DecorationRangeHandler {
         if (comments.length === 0) return;
 
         for (const comment of comments) {
-            if (comment.startDelimiter === undefined || comment.content === undefined)
-                continue;
 
             // Extract arguments for this comment
             const match = colorBlockRegex.exec(comment.content);

--- a/src/decorationRangeHandler.ts
+++ b/src/decorationRangeHandler.ts
@@ -107,6 +107,9 @@ export class DecorationRangeHandler {
         if (comments.length === 0) return;
 
         for (const comment of comments) {
+            if (comment.startDelimiter === undefined || comment.content === undefined)
+                continue;
+
             // Extract arguments for this comment
             const match = colorBlockRegex.exec(comment.content);
 


### PR DESCRIPTION
## Summary
- Build comment detection regex from an array of patterns to avoid trailing `|`
- Ignore comment matches missing delimiters before computing offsets

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run compile`
- `node - <<'NODE' ...` (parse sample `.sh` file without crashing)


------
https://chatgpt.com/codex/tasks/task_e_68c562628f44833097a7afeb9fb6b419